### PR TITLE
Command God Rework

### DIFF
--- a/API/src/main/java/fr/maxlego08/essentials/api/commands/Permission.java
+++ b/API/src/main/java/fr/maxlego08/essentials/api/commands/Permission.java
@@ -24,6 +24,7 @@ public enum Permission {
     ESSENTIALS_ENDERSEE_OFFLINE("Allows you to see the enderchest of an offline player"),
     ESSENTIALS_TOP,
     ESSENTIALS_GOD,
+    ESSENTIALS_GOD_OTHER,
     ESSENTIALS_HEAL,
     ESSENTIALS_SPEED,
     ESSENTIALS_TELEPORT_BYPASS("Allows to bypass the waiting time for teleportation"),

--- a/src/main/java/fr/maxlego08/essentials/commands/commands/utils/admins/CommandGod.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/utils/admins/CommandGod.java
@@ -9,20 +9,22 @@ import fr.maxlego08.essentials.api.user.User;
 import fr.maxlego08.essentials.zutils.utils.AttributeUtils;
 import fr.maxlego08.essentials.zutils.utils.commands.VCommand;
 import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
+
+import java.util.logging.Level;
 
 public class CommandGod extends VCommand {
     public CommandGod(EssentialsPlugin plugin) {
         super(plugin);
         this.setPermission(Permission.ESSENTIALS_GOD);
         this.setDescription(Message.DESCRIPTION_GOD);
-        this.addOptionalArg("player");
+        this.addOptionalArg("player", getOnlinePlayers());
     }
 
     @Override
     protected CommandResultType perform(EssentialsPlugin plugin) {
-
         Player player = this.argAsPlayer(0, this.player);
 
         if (player == null) {
@@ -30,26 +32,66 @@ public class CommandGod extends VCommand {
         }
 
         if (player == this.player) {
-            toggleGodMode(player, this.user, sender);
+            // Self god mode - uses the existing permission
+            toggleGodMode(player, this.user, this.sender);
         } else {
+            // God mode for others - check for additional permission
+            if (!hasPermission(this.sender, Permission.ESSENTIALS_GOD_OTHER)) {
+                message(this.sender, Message.COMMAND_NO_PERMISSION);
+                return CommandResultType.NO_PERMISSION;
+            }
+
             User otherUser = getUser(player);
-            toggleGodMode(player, otherUser, sender);
+            toggleGodMode(player, otherUser, this.sender);
         }
 
         return CommandResultType.SUCCESS;
     }
 
-    private void toggleGodMode(Player player, User user, CommandSender sender) {
-
-        user.setOption(Option.GOD, !user.getOption(Option.GOD));
+    private void toggleGodMode(Player target, User user, CommandSender sender) {
+        boolean wasGodEnabled = user.getOption(Option.GOD);
+        user.setOption(Option.GOD, !wasGodEnabled);
         boolean isGodEnabled = user.getOption(Option.GOD);
 
         if (isGodEnabled) {
-            player.setHealth(player.getAttribute(AttributeUtils.getAttribute("max_health")).getBaseValue());
-            player.setFoodLevel(20);
+            try {
+                setPlayerHealthAndFood(target);
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.WARNING, "Error setting god mode health/food for " + target.getName(), e);
+            }
         }
 
+        // Send messages
+        sendGodModeMessages(target, sender, isGodEnabled);
+    }
+
+    private void sendGodModeMessages(Player target, CommandSender sender, boolean isGodEnabled) {
         Message messageKey = isGodEnabled ? Message.COMMAND_GOD_ENABLE : Message.COMMAND_GOD_DISABLE;
-        message(sender, messageKey, "%player%", user == this.user ? Message.YOU.getMessageAsString() : player.getName());
+
+        // Message for the sender
+        boolean isSelf = sender.equals(target);
+        String senderMessage = isSelf ? Message.YOU.getMessageAsString() : target.getName();
+        message(sender, messageKey, "%player%", senderMessage);
+
+        // Message for the target (if different from sender)
+        if (!isSelf) {
+            message(target, messageKey, "%player%", Message.YOU.getMessageAsString());
+        }
+    }
+
+    private void setPlayerHealthAndFood(Player player) {
+        // Set health to max health value or fallback to 20.0
+        Attribute maxHealthAttribute = AttributeUtils.getAttribute("max_health");
+        double maxHealth = 20.0; // Default fallback
+
+        if (maxHealthAttribute != null) {
+            AttributeInstance attributeInstance = player.getAttribute(maxHealthAttribute);
+            if (attributeInstance != null) {
+                maxHealth = attributeInstance.getBaseValue();
+            }
+        }
+
+        player.setHealth(maxHealth);
+        player.setFoodLevel(20);
     }
 }

--- a/src/main/java/fr/maxlego08/essentials/commands/commands/utils/admins/CommandGod.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/utils/admins/CommandGod.java
@@ -16,6 +16,10 @@ import org.bukkit.entity.Player;
 import java.util.logging.Level;
 
 public class CommandGod extends VCommand {
+    // Constants at class level
+    private static final double DEFAULT_MAX_HEALTH = 20.0;
+    private static final int DEFAULT_MAX_FOOD_LEVEL = 20;
+
     public CommandGod(EssentialsPlugin plugin) {
         super(plugin);
         this.setPermission(Permission.ESSENTIALS_GOD);
@@ -80,9 +84,9 @@ public class CommandGod extends VCommand {
     }
 
     private void setPlayerHealthAndFood(Player player) {
-        // Set health to max health value or fallback to 20.0
+        // Set health to max health value or fallback to default
         Attribute maxHealthAttribute = AttributeUtils.getAttribute("max_health");
-        double maxHealth = 20.0; // Default fallback
+        double maxHealth = DEFAULT_MAX_HEALTH; // Use constant as fallback
 
         if (maxHealthAttribute != null) {
             AttributeInstance attributeInstance = player.getAttribute(maxHealthAttribute);
@@ -92,6 +96,6 @@ public class CommandGod extends VCommand {
         }
 
         player.setHealth(maxHealth);
-        player.setFoodLevel(20);
+        player.setFoodLevel(DEFAULT_MAX_FOOD_LEVEL);
     }
 }

--- a/src/main/java/fr/maxlego08/essentials/commands/commands/utils/admins/CommandGod.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/utils/admins/CommandGod.java
@@ -62,6 +62,9 @@ public class CommandGod extends VCommand {
                 setPlayerHealthAndFood(target);
             } catch (Exception e) {
                 plugin.getLogger().log(Level.WARNING, "Error setting god mode health/food for " + target.getName(), e);
+                // Revert god mode state to maintain consistency
+                user.setOption(Option.GOD, wasGodEnabled);
+                isGodEnabled = wasGodEnabled;
             }
         }
 

--- a/src/main/java/fr/maxlego08/essentials/zutils/utils/AttributeUtils.java
+++ b/src/main/java/fr/maxlego08/essentials/zutils/utils/AttributeUtils.java
@@ -6,7 +6,6 @@ import org.bukkit.attribute.Attribute;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 public class AttributeUtils {
 
@@ -14,16 +13,14 @@ public class AttributeUtils {
 
     public static Attribute getAttribute(String name) {
         return attributeCache.computeIfAbsent(name, key -> {
-            try {
-                return Registry.ATTRIBUTE.getOrThrow(NamespacedKey.minecraft(key));
-            } catch (NoSuchElementException ignored) {
-                try {
-                    return Registry.ATTRIBUTE.getOrThrow(NamespacedKey.minecraft("generic." + key));
-                } catch (NoSuchElementException e) {
-                    e.printStackTrace();
-                    return null;
-                }
+            // Try with the key as-is first
+            Attribute attribute = Registry.ATTRIBUTE.get(NamespacedKey.minecraft(key));
+            if (attribute != null) {
+                return attribute;
             }
+
+            // Try with "generic." prefix and return result (null if not found)
+            return Registry.ATTRIBUTE.get(NamespacedKey.minecraft("generic." + key));
         });
     }
 }


### PR DESCRIPTION
Had no idea how to edit previous PR so decided to create new one. 
Changes:
- Refactored `AttributeUtils` function to avoid `.getOrThrow`, improving compatibility across versions.
- Made various improvements to the God command:
  - Added support for "god other" permission node.
  - Implemented tab completion.
  - Streamlined and cleaned up the code for better maintainability and adaptability.
  - Fixed syntax error that occurred when enabling God mode.
  - With new changes supported versions should be 1.20.6 & 1.21

