### PR TITLE
feat: add per-world random teleport configuration

### DIFF
--- a/API/src/main/java/fr/maxlego08/essentials/api/teleportation/RandomTeleportWorld.java
+++ b/API/src/main/java/fr/maxlego08/essentials/api/teleportation/RandomTeleportWorld.java
@@ -1,0 +1,6 @@
+package fr.maxlego08.essentials.api.teleportation;
+
+import fr.maxlego08.essentials.api.modules.Loadable;
+
+public record RandomTeleportWorld(String world, int centerX, int centerZ, int radiusX, int radiusZ) implements Loadable {
+}

--- a/src/main/java/fr/maxlego08/essentials/module/modules/TeleportationModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/TeleportationModule.java
@@ -1,20 +1,24 @@
 package fr.maxlego08.essentials.module.modules;
 
 import fr.maxlego08.essentials.ZEssentialsPlugin;
+import fr.maxlego08.essentials.api.configuration.NonLoadable;
 import fr.maxlego08.essentials.api.messages.Message;
+import fr.maxlego08.essentials.api.teleportation.RandomTeleportWorld;
 import fr.maxlego08.essentials.api.teleportation.TeleportPermission;
 import fr.maxlego08.essentials.api.user.User;
 import fr.maxlego08.essentials.module.ZModule;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 public class TeleportationModule extends ZModule {
 
@@ -31,11 +35,9 @@ public class TeleportationModule extends ZModule {
     private boolean openConfirmInventoryForTpa;
     private boolean openConfirmInventoryForTpaHere;
     private int maxRtpAttempts;
-    private int rtpCenterX;
-    private int rtpCenterZ;
-    private int rtpRadiusX;
-    private int rtpRadiusZ;
-    private String rtpWorld = "world";
+    private final List<RandomTeleportWorld> rtpWorlds = new ArrayList<>();
+    @NonLoadable
+    private Map<String, RandomTeleportWorld> rtpWorldMap = new HashMap<>();
 
 
     public TeleportationModule(ZEssentialsPlugin plugin) {
@@ -48,6 +50,8 @@ public class TeleportationModule extends ZModule {
 
         this.loadInventory("confirm_request_inventory");
         this.loadInventory("confirm_request_here_inventory");
+
+        this.rtpWorldMap = this.rtpWorlds.stream().collect(Collectors.toMap(RandomTeleportWorld::world, r -> r));
     }
 
     public boolean isTeleportSafety() {
@@ -99,8 +103,14 @@ public class TeleportationModule extends ZModule {
     }
 
     public void randomTeleport(Player player) {
-        World world = Bukkit.getWorld(this.rtpWorld);
-        this.randomTeleport(player, world, this.rtpCenterX, this.rtpCenterZ, this.rtpRadiusX, this.rtpRadiusZ);
+        RandomTeleportWorld configuration = this.rtpWorldMap.get(player.getWorld().getName());
+        if (configuration == null) {
+            message(player, Message.COMMAND_RANDOM_TP_ERROR);
+            return;
+        }
+
+        World world = player.getWorld();
+        this.randomTeleport(player, world, configuration.centerX(), configuration.centerZ(), configuration.radiusX(), configuration.radiusZ());
     }
 
 

--- a/src/main/resources/modules/teleportation/config.yml
+++ b/src/main/resources/modules/teleportation/config.yml
@@ -43,13 +43,12 @@ open-confirm-inventory-for-tpa: false
 # Opens a confirmation inventory for the /tpahere command.
 open-confirm-inventory-for-tpa-here: false
 
-rtp-center-x: 0
-rtp-center-z: 0
-
-rtp-radius-x: 5000
-rtp-radius-z: 5000
-
-rtp-world: "world"
+rtp-worlds:
+  - world: "world"
+    center-x: 0
+    center-z: 0
+    radius-x: 5000
+    radius-z: 5000
 
 max-rtp-attempts: 10
 


### PR DESCRIPTION
## Summary
- support per-world random teleport settings using `RandomTeleportWorld`
- load rtp-worlds from config and apply based on player's world

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies, status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d525d34883219026170eb535e267