### PR TITLE
feat: add admin vault view

### DIFF
--- a/API/src/main/java/fr/maxlego08/essentials/api/vault/PlayerVaults.java
+++ b/API/src/main/java/fr/maxlego08/essentials/api/vault/PlayerVaults.java
@@ -62,6 +62,23 @@ public interface PlayerVaults {
     void setTargetVault(Vault targetVault);
 
     /**
+     * Gets the player vaults currently being viewed by the player.
+     * This is mainly used when an administrator is inspecting another
+     * player's vaults.
+     *
+     * @return the target player's vaults, or {@code null} if the player is
+     * not viewing another player's vaults
+     */
+    PlayerVaults getTargetPlayerVaults();
+
+    /**
+     * Sets the player vaults currently being viewed by the player.
+     *
+     * @param targetPlayerVaults the target player's vaults to view
+     */
+    void setTargetPlayerVaults(PlayerVaults targetPlayerVaults);
+
+    /**
      * Gets a specific vault by its ID.
      *
      * @param vaultId the ID of the vault to retrieve

--- a/src/main/java/fr/maxlego08/essentials/ZEssentialsPlugin.java
+++ b/src/main/java/fr/maxlego08/essentials/ZEssentialsPlugin.java
@@ -65,7 +65,9 @@ import fr.maxlego08.essentials.loader.ButtonKitGetLoader;
 import fr.maxlego08.essentials.loader.ButtonOptionLoader;
 import fr.maxlego08.essentials.loader.ButtonSanctionLoader;
 import fr.maxlego08.essentials.loader.ButtonVaultNoPermissionLoader;
+import fr.maxlego08.essentials.loader.ButtonVaultNoPermissionAdminLoader;
 import fr.maxlego08.essentials.loader.ButtonVaultOpenLoader;
+import fr.maxlego08.essentials.loader.ButtonVaultOpenAdminLoader;
 import fr.maxlego08.essentials.loader.ButtonWarpLoader;
 import fr.maxlego08.essentials.messages.MessageLoader;
 import fr.maxlego08.essentials.module.ZModuleManager;
@@ -335,6 +337,8 @@ public final class ZEssentialsPlugin extends ZPlugin implements EssentialsPlugin
         this.buttonManager.register(new ButtonKitGetLoader(this));
         this.buttonManager.register(new ButtonVaultOpenLoader(this));
         this.buttonManager.register(new ButtonVaultNoPermissionLoader(this));
+        this.buttonManager.register(new ButtonVaultOpenAdminLoader(this));
+        this.buttonManager.register(new ButtonVaultNoPermissionAdminLoader(this));
         this.buttonManager.register(new ButtonOptionLoader(this));
 
     }

--- a/src/main/java/fr/maxlego08/essentials/buttons/vault/ButtonVaultNoPermissionAdmin.java
+++ b/src/main/java/fr/maxlego08/essentials/buttons/vault/ButtonVaultNoPermissionAdmin.java
@@ -1,0 +1,36 @@
+package fr.maxlego08.essentials.buttons.vault;
+
+import fr.maxlego08.essentials.api.EssentialsPlugin;
+import fr.maxlego08.essentials.api.vault.PlayerVaults;
+import fr.maxlego08.essentials.api.vault.Vault;
+import fr.maxlego08.menu.api.button.Button;
+import fr.maxlego08.menu.api.utils.Placeholders;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class ButtonVaultNoPermissionAdmin extends Button {
+
+    private final int vaultId;
+    private final EssentialsPlugin plugin;
+
+    public ButtonVaultNoPermissionAdmin(EssentialsPlugin plugin, int vaultId) {
+        this.vaultId = vaultId;
+        this.plugin = plugin;
+    }
+
+    @Override
+    public ItemStack getCustomItemStack(Player player) {
+        PlayerVaults viewerVaults = plugin.getVaultManager().getPlayerVaults(player);
+        PlayerVaults targetVaults = viewerVaults.getTargetPlayerVaults();
+        if (targetVaults == null) return this.getItemStack().build(player, false, new Placeholders());
+        Vault vault = targetVaults.getVault(this.vaultId);
+
+        var itemstack = this.getItemStack();
+        Placeholders placeholders = new Placeholders();
+
+        placeholders.register("vault-name", vault.getName());
+
+        return itemstack.build(player, false, placeholders);
+    }
+}
+

--- a/src/main/java/fr/maxlego08/essentials/buttons/vault/ButtonVaultOpenAdmin.java
+++ b/src/main/java/fr/maxlego08/essentials/buttons/vault/ButtonVaultOpenAdmin.java
@@ -1,0 +1,84 @@
+package fr.maxlego08.essentials.buttons.vault;
+
+import fr.maxlego08.essentials.api.EssentialsPlugin;
+import fr.maxlego08.essentials.api.vault.PlayerVaults;
+import fr.maxlego08.essentials.api.vault.Vault;
+import fr.maxlego08.menu.api.button.Button;
+import fr.maxlego08.menu.api.engine.InventoryEngine;
+import fr.maxlego08.menu.api.utils.Placeholders;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.plugin.Plugin;
+
+public class ButtonVaultOpenAdmin extends Button {
+
+    private final EssentialsPlugin plugin;
+    private final int vaultId;
+
+    public ButtonVaultOpenAdmin(Plugin plugin, int vaultId) {
+        this.plugin = (EssentialsPlugin) plugin;
+        this.vaultId = vaultId;
+    }
+
+    @Override
+    public ItemStack getCustomItemStack(Player player) {
+        PlayerVaults viewerVaults = this.plugin.getVaultManager().getPlayerVaults(player);
+        PlayerVaults targetVaults = viewerVaults.getTargetPlayerVaults();
+        if (targetVaults == null) return this.getItemStack().build(player, false, new Placeholders());
+
+        Vault targetVault = targetVaults.getVault(this.vaultId);
+        Vault currentVault = viewerVaults.getTargetVault();
+
+        var itemstack = this.getItemStack();
+        Placeholders placeholders = new Placeholders();
+        var vaultManager = plugin.getVaultManager();
+
+        var vaultItemStack = targetVault.getIconItemStack();
+        var icon = vaultItemStack != null ? vaultItemStack.getType().name() : currentVault.getVaultId() == this.vaultId ? vaultManager.getIconOpen() : vaultManager.getIconClose();
+        var modelId = vaultItemStack != null && vaultItemStack.hasItemMeta() && vaultItemStack.getItemMeta().hasCustomModelData() ? vaultItemStack.getItemMeta().getCustomModelData() : currentVault.getVaultId() == this.vaultId ? vaultManager.getIconOpenModelId() : vaultManager.getIconCloseModelId();
+
+        placeholders.register("vault-icon", icon);
+        placeholders.register("vault-model-id", String.valueOf(modelId));
+        placeholders.register("vault-name", targetVault.getName());
+        placeholders.register("vault-id", String.valueOf(this.vaultId));
+
+        return itemstack.build(player, false, placeholders);
+    }
+
+    @Override
+    public void onLeftClick(Player player, InventoryClickEvent event, InventoryEngine inventory, int slot) {
+        super.onLeftClick(player, event, inventory, slot);
+
+        PlayerVaults viewerVaults = plugin.getVaultManager().getPlayerVaults(player);
+        PlayerVaults targetVaults = viewerVaults.getTargetPlayerVaults();
+        if (targetVaults == null) return;
+
+        Vault vault = viewerVaults.getTargetVault();
+        if (vault == null || vault.getVaultId() == this.vaultId) return;
+
+        this.plugin.getVaultManager().openVault(player, Bukkit.getOfflinePlayer(targetVaults.getUniqueId()), this.vaultId);
+    }
+
+    @Override
+    public void onRightClick(Player player, InventoryClickEvent event, InventoryEngine inventory, int slot) {
+        super.onRightClick(player, event, inventory, slot);
+
+        // Keep same behavior as default button; open configuration for player's own vault if permitted
+        this.plugin.getVaultManager().openConfiguration(player, this.vaultId);
+    }
+
+    @Override
+    public boolean hasPermission() {
+        return true;
+    }
+
+    @Override
+    public boolean checkPermission(Player player, InventoryEngine inventory, Placeholders placeholders) {
+        PlayerVaults viewerVaults = this.plugin.getVaultManager().getPlayerVaults(player);
+        PlayerVaults targetVaults = viewerVaults.getTargetPlayerVaults();
+        return targetVaults != null && this.plugin.getVaultManager().hasPermission(targetVaults.getUniqueId(), this.vaultId);
+    }
+}
+

--- a/src/main/java/fr/maxlego08/essentials/buttons/vault/ButtonVaultSlotItems.java
+++ b/src/main/java/fr/maxlego08/essentials/buttons/vault/ButtonVaultSlotItems.java
@@ -9,6 +9,7 @@ import fr.maxlego08.essentials.api.vault.VaultResult;
 import fr.maxlego08.menu.api.button.Button;
 import fr.maxlego08.menu.api.engine.InventoryEngine;
 import fr.maxlego08.menu.api.utils.Placeholders;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.ClickType;
@@ -42,6 +43,8 @@ public class ButtonVaultSlotItems extends Button {
         if (vault == null) return;
 
         placeholders.register("vault-name", vault.getName());
+        var owner = Bukkit.getOfflinePlayer(vault.getUniqueId());
+        placeholders.register("player", owner.getName());
     }
 
     @Override

--- a/src/main/java/fr/maxlego08/essentials/loader/ButtonVaultNoPermissionAdminLoader.java
+++ b/src/main/java/fr/maxlego08/essentials/loader/ButtonVaultNoPermissionAdminLoader.java
@@ -1,0 +1,25 @@
+package fr.maxlego08.essentials.loader;
+
+import fr.maxlego08.essentials.api.EssentialsPlugin;
+import fr.maxlego08.essentials.buttons.vault.ButtonVaultNoPermissionAdmin;
+import fr.maxlego08.menu.api.button.Button;
+import fr.maxlego08.menu.api.button.DefaultButtonValue;
+import fr.maxlego08.menu.api.loader.ButtonLoader;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+public class ButtonVaultNoPermissionAdminLoader extends ButtonLoader {
+
+    private final EssentialsPlugin plugin;
+
+    public ButtonVaultNoPermissionAdminLoader(EssentialsPlugin plugin) {
+        super(plugin, "ZESSENTIALS_VAULT_NO_PERMISSION_ADMIN");
+        this.plugin = plugin;
+    }
+
+    @Override
+    public Button load(YamlConfiguration configuration, String path, DefaultButtonValue defaultButtonValue) {
+        int vaultId = Integer.parseInt(configuration.getString(path + "vault", "1"));
+        return new ButtonVaultNoPermissionAdmin(this.plugin, vaultId);
+    }
+}
+

--- a/src/main/java/fr/maxlego08/essentials/loader/ButtonVaultOpenAdminLoader.java
+++ b/src/main/java/fr/maxlego08/essentials/loader/ButtonVaultOpenAdminLoader.java
@@ -1,0 +1,25 @@
+package fr.maxlego08.essentials.loader;
+
+import fr.maxlego08.essentials.api.EssentialsPlugin;
+import fr.maxlego08.essentials.buttons.vault.ButtonVaultOpenAdmin;
+import fr.maxlego08.menu.api.button.Button;
+import fr.maxlego08.menu.api.button.DefaultButtonValue;
+import fr.maxlego08.menu.api.loader.ButtonLoader;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+public class ButtonVaultOpenAdminLoader extends ButtonLoader {
+
+    private final EssentialsPlugin plugin;
+
+    public ButtonVaultOpenAdminLoader(EssentialsPlugin plugin) {
+        super(plugin, "ZESSENTIALS_VAULT_OPEN_ADMIN");
+        this.plugin = plugin;
+    }
+
+    @Override
+    public Button load(YamlConfiguration configuration, String path, DefaultButtonValue defaultButtonValue) {
+        int vaultId = Integer.parseInt(configuration.getString(path + "vault", "1"));
+        return new ButtonVaultOpenAdmin(this.plugin, vaultId);
+    }
+}
+

--- a/src/main/java/fr/maxlego08/essentials/module/modules/vault/VaultModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/vault/VaultModule.java
@@ -58,6 +58,7 @@ public class VaultModule extends ZModule implements VaultManager {
 
         this.loadInventory("vault");
         this.loadInventory("vault-configuration");
+        this.loadInventory("vault-admin");
     }
 
     @Override
@@ -104,6 +105,7 @@ public class VaultModule extends ZModule implements VaultManager {
         PlayerVaults playerVaults = getPlayerVaults(player);
         Vault vault = playerVaults.getVault(vaultId);
         playerVaults.setTargetVault(vault);
+        playerVaults.setTargetPlayerVaults(playerVaults);
 
         this.plugin.openInventory(player, "vault");
     }
@@ -125,8 +127,9 @@ public class VaultModule extends ZModule implements VaultManager {
         Vault vault = targetVaults.getVault(vaultId);
         PlayerVaults viewerVaults = getPlayerVaults(player);
         viewerVaults.setTargetVault(vault);
+        viewerVaults.setTargetPlayerVaults(targetVaults);
 
-        this.plugin.openInventory(player, "vault");
+        this.plugin.openInventory(player, "vault-admin");
     }
 
     @Override
@@ -316,6 +319,7 @@ public class VaultModule extends ZModule implements VaultManager {
         PlayerVaults playerVaults = getPlayerVaults(player);
         Vault vault = playerVaults.getVault(vaultId);
         playerVaults.setTargetVault(vault);
+        playerVaults.setTargetPlayerVaults(playerVaults);
 
         this.plugin.openInventory(player, "vault-configuration");
     }

--- a/src/main/java/fr/maxlego08/essentials/module/modules/vault/ZPlayerVaults.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/vault/ZPlayerVaults.java
@@ -20,6 +20,7 @@ public class ZPlayerVaults extends ZUtils implements PlayerVaults {
     private final Map<Integer, Vault> vaults = new HashMap<>();
     private int slots;
     private Vault targetVault;
+    private PlayerVaults targetPlayerVaults;
 
     public ZPlayerVaults(VaultManager vaultManager, UUID uniqueId) {
         this.vaultManager = vaultManager;
@@ -59,6 +60,16 @@ public class ZPlayerVaults extends ZUtils implements PlayerVaults {
     @Override
     public void setTargetVault(Vault targetVault) {
         this.targetVault = targetVault;
+    }
+
+    @Override
+    public PlayerVaults getTargetPlayerVaults() {
+        return this.targetPlayerVaults;
+    }
+
+    @Override
+    public void setTargetPlayerVaults(PlayerVaults targetPlayerVaults) {
+        this.targetPlayerVaults = targetPlayerVaults;
     }
 
     @Override

--- a/src/main/resources/modules/vault/vault-admin.yml
+++ b/src/main/resources/modules/vault/vault-admin.yml
@@ -1,0 +1,165 @@
+name: "&f%player% - %vault-name%"
+size: 54
+items:
+  disableSlots:
+    isPermanent: true
+    type: ZESSENTIALS_VAULT_SLOTS_DISABLE
+    slots:
+      - 0-44
+    item:
+      material: STRUCTURE_VOID
+      name: "<red>ʏᴏᴜ ᴅᴏɴ’ᴛ ʜᴀᴠᴇ ᴛʜɪs sʟᴏᴛ"
+  slots:
+    isPermanent: true
+    type: ZESSENTIALS_VAULT_SLOTS_ITEMS
+    slots:
+      - 0-44
+
+  # Navigation
+  vault1:
+    type: ZESSENTIALS_VAULT_OPEN_ADMIN
+    vault: 1
+    slot: 46
+    item:
+      material: "%vault-icon%"
+      name: "%vault-name%"
+      amount: "%vault-id%"
+      lore:
+        - "&8Click to open the vault %vault-id%"
+    else:
+      type: ZESSENTIALS_VAULT_NO_PERMISSION_ADMIN
+      vault: 1
+      item:
+        material: BARRIER
+        name: "%vault-name%"
+        lore:
+          - ""
+          - "<red>✘ You do not have access to se vault"
+          - ""
+          - "&7Get slots on the shop!"
+  vault2:
+    type: ZESSENTIALS_VAULT_OPEN_ADMIN
+    vault: 2
+    slot: 47
+    item:
+      material: "%vault-icon%"
+      name: "%vault-name%"
+      amount: 5
+      lore:
+        - "&8Click to open the vault %vault-id%"
+    else:
+      type: ZESSENTIALS_VAULT_NO_PERMISSION_ADMIN
+      vault: 2
+      item:
+        material: BARRIER
+        name: "%vault-name%"
+        lore:
+          - ""
+          - "<red>✘ You do not have access to se vault"
+          - ""
+          - "&7Get slots on the shop!"
+  vault3:
+    type: ZESSENTIALS_VAULT_OPEN_ADMIN
+    vault: 3
+    slot: 48
+    item:
+      material: "%vault-icon%"
+      name: "%vault-name%"
+      amount: "%vault-id%"
+      lore:
+        - "&8Click to open the vault %vault-id%"
+    else:
+      type: ZESSENTIALS_VAULT_NO_PERMISSION_ADMIN
+      vault: 3
+      item:
+        material: BARRIER
+        name: "%vault-name%"
+        lore:
+          - ""
+          - "<red>✘ You do not have access to se vault"
+          - ""
+          - "&7Get slots on the shop!"
+  vault4:
+    type: ZESSENTIALS_VAULT_OPEN_ADMIN
+    vault: 4
+    slot: 49
+    item:
+      material: "%vault-icon%"
+      name: "%vault-name%"
+      amount: "%vault-id%"
+      lore:
+        - "&8Click to open the vault %vault-id%"
+    else:
+      type: ZESSENTIALS_VAULT_NO_PERMISSION_ADMIN
+      vault: 4
+      item:
+        material: BARRIER
+        name: "%vault-name%"
+        lore:
+          - ""
+          - "<red>✘ You do not have access to se vault"
+          - ""
+          - "&7Get slots on the shop!"
+  vault5:
+    type: ZESSENTIALS_VAULT_OPEN_ADMIN
+    vault: 5
+    slot: 50
+    item:
+      material: "%vault-icon%"
+      name: "%vault-name%"
+      amount: "%vault-id%"
+      lore:
+        - "&8Click to open the vault %vault-id%"
+    else:
+      type: ZESSENTIALS_VAULT_NO_PERMISSION_ADMIN
+      vault: 5
+      item:
+        material: BARRIER
+        name: "%vault-name%"
+        lore:
+          - ""
+          - "<red>✘ You do not have access to se vault"
+          - ""
+          - "&7Get slots on the shop!"
+  vault6:
+    type: ZESSENTIALS_VAULT_OPEN_ADMIN
+    vault: 6
+    slot: 51
+    item:
+      material: "%vault-icon%"
+      name: "%vault-name%"
+      amount: "%vault-id%"
+      lore:
+        - "&8Click to open the vault %vault-id%"
+    else:
+      type: ZESSENTIALS_VAULT_NO_PERMISSION_ADMIN
+      vault: 6
+      item:
+        material: BARRIER
+        name: "%vault-name%"
+        lore:
+          - ""
+          - "<red>✘ You do not have access to se vault"
+          - ""
+          - "&7Get slots on the shop!"
+  vault7:
+    type: ZESSENTIALS_VAULT_OPEN_ADMIN
+    vault: 7
+    slot: 52
+    item:
+      material: "%vault-icon%"
+      name: "%vault-name%"
+      amount: "%vault-id%"
+      lore:
+        - "&8Click to open the vault %vault-id%"
+    else:
+      type: ZESSENTIALS_VAULT_NO_PERMISSION_ADMIN
+      vault: 7
+      item:
+        material: BARRIER
+        name: "%vault-name%"
+        lore:
+          - ""
+          - "<red>✘ You do not have access to se vault"
+          - ""
+          - "&7Get slots on the shop!"


### PR DESCRIPTION
## Summary
- add API support for tracking viewed player vaults
- implement admin-specific vault buttons and inventory
- load admin vault inventory and button loaders

## Testing
- `./gradlew test` *(fails: Could not resolve io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_68a3054bc0c08321aaab7028a1722d71