### PR TITLE
Ensure database user records exist before related inserts

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/storage/database/repositeries/UserRepository.java
+++ b/src/main/java/fr/maxlego08/essentials/storage/database/repositeries/UserRepository.java
@@ -144,6 +144,10 @@ public class UserRepository extends Repository {
         return select(UserVoteDTO.class, table -> table.where("unique_id", uniqueId));
     }
 
+    public boolean exists(UUID uniqueId) {
+        return !selectUser(uniqueId).isEmpty();
+    }
+
     /**
      * Returns the total number of users.
      *


### PR DESCRIPTION
## Summary
- ensure SQL storage creates missing user rows before queuing mailbox inserts or economy updates
- add a repository helper to detect existing user rows

## Testing
- `./gradlew test` *(fails: Gradle distribution download blocked by proxy 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68de7710726c8321b0e788a23f12a3bd