### PR TITLE
Restore /spawn cooldown for player self teleports

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/commands/commands/spawn/CommandSpawn.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/spawn/CommandSpawn.java
@@ -34,13 +34,25 @@ public class CommandSpawn extends VCommand {
         User user = this.plugin.getUser(player.getUniqueId());
         if (user == null) return CommandResultType.SYNTAX_ERROR; // Only if its console
 
+        if (ConfigStorage.spawnLocation == null || !ConfigStorage.spawnLocation.isValid()) {
+            message(sender, Message.COMMAND_SPAWN_NOT_DEFINE);
+            return CommandResultType.DEFAULT;
+        }
+
         Location location = ConfigStorage.spawnLocation.getLocation();
         if (location == null) {
             message(sender, Message.COMMAND_SPAWN_NOT_DEFINE);
             return CommandResultType.DEFAULT;
         }
 
-        user.teleport(location, Message.TELEPORT_MESSAGE_SPAWN, Message.TELEPORT_SUCCESS_SPAWN);
+        boolean teleportingSelf = this.user != null && user == this.user;
+
+        if (teleportingSelf) {
+            user.teleport(location, Message.TELEPORT_MESSAGE_SPAWN, Message.TELEPORT_SUCCESS_SPAWN);
+        } else {
+            user.teleportNow(location);
+            message(user, Message.TELEPORT_SUCCESS_SPAWN);
+        }
         if (this.user == null || user != this.user) {
             message(sender, Message.TELEPORT_MESSAGE_SPAWN_CONSOLE, player);
         }


### PR DESCRIPTION
## Summary
- restore the standard timed teleport flow when players use /spawn on themselves
- keep instant teleportation for console or staff teleporting other players while preserving spawn messaging
- leave the spawn location validity checks in place

## Testing
- ./gradlew test --stacktrace --console=plain *(fails: dependencies return HTTP 403 from upstream Maven repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68f223210238832198dc632ffc00e080