### PR TITLE
Handle full vault slot checks when adding items

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/module/modules/vault/VaultModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/vault/VaultModule.java
@@ -212,12 +212,22 @@ public class VaultModule extends ZModule implements VaultManager {
 
     @Override
     public VaultResult addNewItemToVault(Vault vault, UUID uniqueId, ItemStack currentItem, int quantity, int size, int totalSlots, int slot) {
-        int nextSlot = vault.getNextSlot() + ((vault.getVaultId() - 1) * size);
-        if (nextSlot == -1 || nextSlot >= totalSlots) {
+        int nextSlot = vault.getNextSlot();
+        if (nextSlot == -1) {
             return null;
         }
 
-        if (slot == -1) slot = vault.getNextSlot();
+        int virtualNextSlot = nextSlot + ((vault.getVaultId() - 1) * size);
+        if (virtualNextSlot >= totalSlots) {
+            return null;
+        }
+
+        if (slot == -1) {
+            slot = nextSlot;
+            if (slot == -1) {
+                return null;
+            }
+        }
 
         VaultItem newVaultItem = new ZVaultItem(slot, currentItem, quantity);
         vault.getVaultItems().put(slot, newVaultItem);


### PR DESCRIPTION
## Summary
- prevent creating vault entries when no free slot is available
- ensure computed virtual slot does not exceed the available inventory range

## Testing
- `./gradlew test` *(fails: remote Maven repositories return 403 responses in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fb62f4a9cc8321a276b1cc233faaca