### PR TITLE
Add configurable local and global chat handling

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/module/modules/chat/ChatModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/chat/ChatModule.java
@@ -93,6 +93,8 @@ public class ChatModule extends ZModule {
     private String playerPingColorOther;
     private float playerPingSoundVolume;
     private float playerPingSoundPitch;
+    private boolean enableLocalChat;
+    private double localChatDistance;
 
 
     public ChatModule(ZEssentialsPlugin plugin) {
@@ -169,6 +171,12 @@ public class ChatModule extends ZModule {
         }
 
         String message = PlainTextComponentSerializer.plainText().serialize(event.originalMessage());
+        boolean isGlobalChat = false;
+
+        if (this.enableLocalChat && message.startsWith("!")) {
+            isGlobalChat = true;
+            message = message.substring(1).stripLeading();
+        }
         final String minecraftMessage = message;
 
         Optional<CustomRules> optional = this.customRules.stream().filter(rule -> rule.match(player, minecraftMessage)).findFirst();
@@ -206,6 +214,10 @@ public class ChatModule extends ZModule {
         }
 
         String finalMessage = message;
+        double maxDistanceSquared = this.localChatDistance * this.localChatDistance;
+        if (this.enableLocalChat && !isGlobalChat) {
+            event.viewers().removeIf(viewer -> viewer instanceof Player playerViewer && (!playerViewer.getWorld().equals(player.getWorld()) || playerViewer.getLocation().distanceSquared(player.getLocation()) > maxDistanceSquared));
+        }
         event.renderer((source, sourceDisplayName, ignoredMessage, viewer) -> {
 
             String localMessage = finalMessage;

--- a/src/main/resources/modules/chat/config.yml
+++ b/src/main/resources/modules/chat/config.yml
@@ -47,6 +47,12 @@ enable-chat-dynamic-cooldown: true
 # Check player tries to put the same message multiple times
 enable-same-message-cancel: true
 
+# Enables local chat where messages are only visible to nearby players unless prefixed with '!'
+enable-local-chat: false
+
+# Maximum distance in blocks for local chat messages
+local-chat-distance: 100
+
 # Apply a format to the chat, disabled on if you want another plugin to handle this
 enable-chat-format: true
 


### PR DESCRIPTION
## Summary
- add configurable local chat mode with optional global override prefix
- expose distance and enablement settings in the chat module configuration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694685aa4750832191f08dacb18bc550)