### PR TITLE
fix: enable cooldown bypass by default

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -59,7 +59,7 @@ redis-configuration:
   password: "123456a"
 
 # If you have enabled this option, players with the essentials.bypass.cooldown permission you can execute commands in command-cooldowns without being assigned
-enable-cooldown-bypass: false
+enable-cooldown-bypass: true
 
 # Create command cooldowns (can run a command after X number of seconds)
 command-cooldowns:


### PR DESCRIPTION
Why disable this by default? I actually thought
it couldn’t be done until I looked at the code…