### PR TITLE
Prevent discord pings from minecraft chat

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/module/modules/discord/DiscordModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/discord/DiscordModule.java
@@ -139,6 +139,7 @@ public class DiscordModule extends ZModule implements DiscordManager {
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onTalk(AsyncChatEvent event) {
         String message = PlainTextComponentSerializer.plainText().serialize(event.message());
+        message = message.replace("@", "@\u200B");
         var player = event.getPlayer();
         sendDiscordMessage(player, player.getName(), player.getUniqueId(), message, this.chatConfiguration);
     }


### PR DESCRIPTION
Replaced all occurrences of the `@` symbol with `@\u200B` (adding a zero-width space).