### PR TITLE
Fix compatibility with newer zMenu versions

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/module/modules/worldedit/WorldeditModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/worldedit/WorldeditModule.java
@@ -33,7 +33,6 @@ import fr.maxlego08.essentials.module.modules.worldedit.taks.WallsTask;
 import fr.maxlego08.essentials.zutils.utils.TimerBuilder;
 import fr.maxlego08.menu.api.MenuItemStack;
 import fr.maxlego08.menu.api.utils.TypedMapAccessor;
-import fr.maxlego08.menu.common.utils.itemstack.MenuItemStackFormMap;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Sound;
@@ -109,8 +108,11 @@ public class WorldeditModule extends ZModule implements WorldeditManager {
             int maxUse = accessor.getInt("max-use", -1);
             double priceMultiplier = accessor.getDouble("price-multiplier", -1);
             Map<String, Object> mapItem = (Map<String, Object>) accessor.getObject("item");
-            MenuItemStack menuItemStack = MenuItemStackFormMap.fromMap(plugin.getInventoryManager(), new File(getFolder(), "config.yml"), name, mapItem);
-
+            MenuItemStack menuItemStack = plugin.getInventoryManager().loadItemStack(
+                    new File(getFolder(), "config.yml"),
+                    name,
+                    mapItem
+            );
             WorldEditItem worldEditItem = new WorldEditItem(name, displayName, maxUse, priceMultiplier, menuItemStack);
             this.worldEditItems.add(worldEditItem);
         }


### PR DESCRIPTION
Now zEssentials fails to start with newer zMenu versions.

Simple fix provided 

Current error looks like this: 
```
[22:24:43 INFO]: [zMenu v1.1.1.3] plugins\zEssentials\modules\worldedit\pw-help.yml loaded successfully !
[22:24:43 ERROR]: Error occurred while enabling zEssentials v1.0.3.5 (Is it up to date?)
java.lang.NoClassDefFoundError: fr/maxlego08/menu/common/utils/itemstack/MenuItemStackFormMap
        at zEssentials-1.0.3.5.jar//fr.maxlego08.essentials.module.modules.worldedit.WorldeditModule.loadConfiguration(WorldeditModule.java:112) ~[?:?]
        at java.base/java.util.HashMap$Values.forEach(HashMap.java:1074) ~[?:?]
        at zEssentials-1.0.3.5.jar//fr.maxlego08.essentials.module.ZModuleManager.loadConfigurations(ZModuleManager.java:95) ~[?:?]
        at zEssentials-1.0.3.5.jar//fr.maxlego08.essentials.module.ZModuleManager.loadModules(ZModuleManager.java:88) ~[?:?]
        at zEssentials-1.0.3.5.jar//fr.maxlego08.essentials.ZEssentialsPlugin.onEnable(ZEssentialsPlugin.java:246) ~[?:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:279) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:207) ~[paper-1.21.11.jar:1.21.11-130-c5a2736]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109) ~[paper-1.21.11.jar:1.21.11-130-c5a2736]
        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:639) ~[paper-1.21.11.jar:1.21.11-130-c5a2736]
        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:596) ~[paper-1.21.11.jar:1.21.11-130-c5a2736]
        at net.minecraft.server.MinecraftServer.initPostWorld(MinecraftServer.java:636) ~[paper-1.21.11.jar:1.21.11-130-c5a2736]
        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:365) ~[paper-1.21.11.jar:1.21.11-130-c5a2736]
        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1253) ~[paper-1.21.11.jar:1.21.11-130-c5a2736]
        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:388) ~[paper-1.21.11.jar:1.21.11-130-c5a2736]
        at java.base/java.lang.Thread.run(Thread.java:1474) ~[?:?]
Caused by: java.lang.ClassNotFoundException: fr.maxlego08.menu.common.utils.itemstack.MenuItemStackFormMap
        at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:208) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:175) ~[paper-api-1.21.11-R0.1-SNAPSHOT.jar:?]
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490) ~[?:?]
```