### PR TITLE
fix: Folia join teleports, safe teleport, warp and menu permissions

### DIFF
--- a/API/src/main/java/fr/maxlego08/essentials/api/utils/Warp.java
+++ b/API/src/main/java/fr/maxlego08/essentials/api/utils/Warp.java
@@ -1,8 +1,10 @@
 package fr.maxlego08.essentials.api.utils;
 
 import fr.maxlego08.essentials.api.commands.Permission;
-import org.bukkit.Location;
 import org.bukkit.permissions.Permissible;
+
+import java.util.Collection;
+import java.util.Locale;
 
 /**
  * Represents a warp location.
@@ -17,6 +19,24 @@ public record Warp(String name, SafeLocation location) {
      * @return true if the permissible entity has permission, false otherwise.
      */
     public boolean hasPermission(Permissible permissible) {
-        return permissible.hasPermission(Permission.ESSENTIALS_WARP_.asPermission(this.name));
+        if (permissible.hasPermission(Permission.ESSENTIALS_WARP.asPermission())) {
+            return true;
+        }
+        return permissible.hasPermission(Permission.ESSENTIALS_WARP_.asPermission(this.name.toLowerCase(Locale.ROOT)));
+    }
+
+    /**
+     * Checks if the permissible can use at least one warp or the global warp permission.
+     */
+    public static boolean canAccessAnyWarp(Permissible permissible, Collection<Warp> warps) {
+        if (permissible.hasPermission(Permission.ESSENTIALS_WARP.asPermission())) {
+            return true;
+        }
+        for (Warp warp : warps) {
+            if (warp.hasPermission(permissible)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/fr/maxlego08/essentials/buttons/ButtonWarp.java
+++ b/src/main/java/fr/maxlego08/essentials/buttons/ButtonWarp.java
@@ -46,6 +46,9 @@ public class ButtonWarp extends Button {
     @Override
     public boolean checkPermission(Player player, InventoryEngine inventory, Placeholders placeholders) {
         Optional<Warp> optional = plugin.getWarp(this.warpName);
-        return super.checkPermission(player, inventory, placeholders) && optional.map(warp -> warp.hasPermission(player)).orElse(false);
+        if (optional.isEmpty() || !optional.get().hasPermission(player)) {
+            return false;
+        }
+        return super.checkPermission(player, inventory, placeholders);
     }
 }

--- a/src/main/java/fr/maxlego08/essentials/buttons/kit/ButtonKitCooldown.java
+++ b/src/main/java/fr/maxlego08/essentials/buttons/kit/ButtonKitCooldown.java
@@ -80,6 +80,9 @@ public class ButtonKitCooldown extends Button {
         User user = this.plugin.getUser(player.getUniqueId());
         if (user == null) return false;
         Optional<Kit> optional = this.plugin.getKit(this.kitName);
-        return optional.filter(kit -> super.checkPermission(player, inventory, placeholders) && user.isKitCooldown(kit)).isPresent();
+        if (optional.isEmpty() || !optional.get().hasPermission(player) || !user.isKitCooldown(optional.get())) {
+            return false;
+        }
+        return super.checkPermission(player, inventory, placeholders);
     }
 }

--- a/src/main/java/fr/maxlego08/essentials/buttons/kit/ButtonKitGet.java
+++ b/src/main/java/fr/maxlego08/essentials/buttons/kit/ButtonKitGet.java
@@ -66,6 +66,9 @@ public class ButtonKitGet extends Button {
         User user = this.plugin.getUser(player.getUniqueId());
         if (user == null) return false;
         Optional<Kit> optional = this.plugin.getKit(this.kitName);
-        return optional.filter(kit -> super.checkPermission(player, inventory, placeholders) && kit.hasPermission(player)).isPresent();
+        if (optional.isEmpty() || !optional.get().hasPermission(player)) {
+            return false;
+        }
+        return super.checkPermission(player, inventory, placeholders);
     }
 }

--- a/src/main/java/fr/maxlego08/essentials/commands/commands/warp/CommandWarp.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/warp/CommandWarp.java
@@ -2,12 +2,12 @@ package fr.maxlego08.essentials.commands.commands.warp;
 
 import fr.maxlego08.essentials.api.EssentialsPlugin;
 import fr.maxlego08.essentials.api.commands.CommandResultType;
-import fr.maxlego08.essentials.api.commands.Permission;
 import fr.maxlego08.essentials.api.messages.Message;
 import fr.maxlego08.essentials.api.utils.Warp;
 import fr.maxlego08.essentials.module.modules.WarpModule;
 import fr.maxlego08.essentials.zutils.utils.commands.VCommand;
 import org.apache.logging.log4j.util.Strings;
+import org.bukkit.command.CommandSender;
 
 import java.util.List;
 
@@ -16,13 +16,20 @@ public class CommandWarp extends VCommand {
     public CommandWarp(EssentialsPlugin plugin) {
         super(plugin);
         this.setModule(WarpModule.class);
-        this.setPermission(Permission.ESSENTIALS_WARP);
         this.setDescription(Message.DESCRIPTION_WARP_USE);
         this.addOptionalArg("name", (sender, args) -> {
             List<Warp> warps = plugin.getWarps();
             return warps.stream().filter(warp -> warp.hasPermission(sender)).map(Warp::name).toList();
         });
         this.onlyPlayers();
+    }
+
+    @Override
+    public CommandResultType prePerform(EssentialsPlugin plugin, CommandSender commandSender, String[] args) {
+        if (!Warp.canAccessAnyWarp(commandSender, plugin.getWarps())) {
+            return CommandResultType.NO_PERMISSION;
+        }
+        return super.prePerform(plugin, commandSender, args);
     }
 
     @Override

--- a/src/main/java/fr/maxlego08/essentials/listener/PlayerListener.java
+++ b/src/main/java/fr/maxlego08/essentials/listener/PlayerListener.java
@@ -221,7 +221,7 @@ public class PlayerListener extends ZUtils implements Listener {
                 player.setFlySpeed(0.1f);
                 player.setWalkSpeed(0.2f);
             }
-        }, 1);
+        }, FoliaJoinHelper.SAFE_LOGIN_DELAY_TICKS);
     }
 
     @EventHandler(priority = EventPriority.LOWEST)

--- a/src/main/java/fr/maxlego08/essentials/listener/PlayerListener.java
+++ b/src/main/java/fr/maxlego08/essentials/listener/PlayerListener.java
@@ -8,7 +8,7 @@ import fr.maxlego08.essentials.api.messages.Message;
 import fr.maxlego08.essentials.api.user.Option;
 import fr.maxlego08.essentials.api.user.User;
 import fr.maxlego08.essentials.api.utils.DynamicCooldown;
-import fr.maxlego08.essentials.storage.ConfigStorage;
+import fr.maxlego08.essentials.zutils.utils.FoliaJoinHelper;
 import fr.maxlego08.essentials.zutils.utils.TimerBuilder;
 import fr.maxlego08.essentials.zutils.utils.ZUtils;
 import org.bukkit.Material;
@@ -190,11 +190,7 @@ public class PlayerListener extends ZUtils implements Listener {
         if (user != null) user.startCurrentSessionPlayTime();
 
         if (user != null && user.isFirstJoin()) {
-            if (ConfigStorage.firstSpawnLocation != null && ConfigStorage.firstSpawnLocation.isValid()) {
-                this.plugin.getScheduler().teleportAsync(player, ConfigStorage.firstSpawnLocation.getLocation());
-            } else if (ConfigStorage.spawnLocation != null && ConfigStorage.spawnLocation.isValid()) {
-                this.plugin.getScheduler().teleportAsync(player, ConfigStorage.spawnLocation.getLocation());
-            }
+            FoliaJoinHelper.teleportFirstSpawnAfterJoin(this.plugin, player);
         }
 
         if (user != null && user.getOption(Option.VANISH)) {

--- a/src/main/java/fr/maxlego08/essentials/module/modules/SanctionModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/SanctionModule.java
@@ -17,6 +17,7 @@ import fr.maxlego08.essentials.api.utils.SafeLocation;
 import fr.maxlego08.essentials.listener.paper.ChatListener;
 import fr.maxlego08.essentials.module.ZModule;
 import fr.maxlego08.essentials.user.ZUser;
+import fr.maxlego08.essentials.zutils.utils.FoliaJoinHelper;
 import fr.maxlego08.essentials.zutils.utils.TimerBuilder;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -446,7 +447,7 @@ public class SanctionModule extends ZModule implements SanctionManager {
                 player.setAllowFlight(true);
                 player.setFlying(true);
                 player.setFlySpeed(0f);
-                this.plugin.getScheduler().teleportAsync(player, player.getLocation().add(0, 0.1, 0));
+                FoliaJoinHelper.teleportAfterJoin(this.plugin, player, player.getLocation().add(0, 0.1, 0));
             }
             this.plugin.getEssentialsServer().sendMessage(user.getUniqueId(), Message.MESSAGE_FREEZE);
         }

--- a/src/main/java/fr/maxlego08/essentials/module/modules/SpawnModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/SpawnModule.java
@@ -5,6 +5,7 @@ import fr.maxlego08.essentials.api.messages.Message;
 import fr.maxlego08.essentials.api.user.User;
 import fr.maxlego08.essentials.module.ZModule;
 import fr.maxlego08.essentials.storage.ConfigStorage;
+import fr.maxlego08.essentials.zutils.utils.FoliaJoinHelper;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -69,7 +70,9 @@ public class SpawnModule extends ZModule {
                     var player = playerJoinEvent.getPlayer();
                     if (ConfigStorage.spawnLocation != null && ConfigStorage.spawnLocation.isValid()) {
                         Location spawnLoc = ConfigStorage.spawnLocation.getLocation();
-                        if (spawnLoc != null) player.teleport(spawnLoc);
+                        if (spawnLoc != null) {
+                            FoliaJoinHelper.teleportAfterJoin(spawnModule.plugin, player, spawnLoc, true);
+                        }
                     }
                 }
             }, this.plugin);
@@ -135,14 +138,4 @@ public class SpawnModule extends ZModule {
         event.setRespawnLocation(ConfigStorage.spawnLocation.getLocation());
     }
 
-    public void onPlayerFirstJoin(Player player) {
-
-        if (!this.isEnable) return;
-
-        if (ConfigStorage.firstSpawnLocation != null && ConfigStorage.firstSpawnLocation.isValid()) {
-            player.teleport(ConfigStorage.firstSpawnLocation.getLocation());
-        } else if (ConfigStorage.spawnLocation != null && ConfigStorage.spawnLocation.isValid()) {
-            player.teleport(ConfigStorage.spawnLocation.getLocation());
-        }
-    }
 }

--- a/src/main/java/fr/maxlego08/essentials/module/modules/kit/KitModule.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/kit/KitModule.java
@@ -34,6 +34,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -116,7 +117,7 @@ public class KitModule extends ZModule {
 
         String name = configuration.getString("name");
         String displayName = configuration.getString("display-name", name);
-        String permission = configuration.getString("permission", Permission.ESSENTIALS_KIT_.asPermission(name));
+        String permission = configuration.getString("permission", Permission.ESSENTIALS_KIT_.asPermission(name.toLowerCase(Locale.ROOT)));
         String category = configuration.getString("category", null);
         String subCategory = configuration.getString("sub-category", null);
 

--- a/src/main/java/fr/maxlego08/essentials/module/modules/kit/ZKit.java
+++ b/src/main/java/fr/maxlego08/essentials/module/modules/kit/ZKit.java
@@ -1,6 +1,7 @@
 package fr.maxlego08.essentials.module.modules.kit;
 
 import fr.maxlego08.essentials.api.EssentialsPlugin;
+import fr.maxlego08.essentials.api.commands.Permission;
 import fr.maxlego08.essentials.api.kit.Kit;
 import fr.maxlego08.essentials.zutils.utils.ZUtils;
 import fr.maxlego08.menu.api.MenuItemStack;
@@ -12,6 +13,7 @@ import org.bukkit.permissions.Permissible;
 
 import java.io.File;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class ZKit extends ZUtils implements Kit {
@@ -125,7 +127,16 @@ public class ZKit extends ZUtils implements Kit {
 
     @Override
     public boolean hasPermission(Permissible permissible) {
-        return permissible.hasPermission(this.permission);
+        if (this.permission == null || this.permission.isEmpty()) {
+            return true;
+        }
+        if (permissible.hasPermission(Permission.ESSENTIALS_KIT.asPermission())) {
+            return true;
+        }
+        if (permissible.hasPermission(this.permission)) {
+            return true;
+        }
+        return permissible.hasPermission(Permission.ESSENTIALS_KIT_.asPermission(this.name.toLowerCase(Locale.ROOT)));
     }
 
     @Override

--- a/src/main/java/fr/maxlego08/essentials/storage/ZStorageManager.java
+++ b/src/main/java/fr/maxlego08/essentials/storage/ZStorageManager.java
@@ -8,7 +8,6 @@ import fr.maxlego08.essentials.api.sanction.Sanction;
 import fr.maxlego08.essentials.api.storage.IStorage;
 import fr.maxlego08.essentials.api.storage.StorageManager;
 import fr.maxlego08.essentials.api.storage.StorageType;
-import fr.maxlego08.essentials.module.modules.SpawnModule;
 import fr.maxlego08.essentials.storage.storages.JsonStorage;
 import fr.maxlego08.essentials.storage.storages.SqlStorage;
 import fr.maxlego08.essentials.zutils.utils.TimerBuilder;
@@ -87,10 +86,6 @@ public class ZStorageManager extends ZUtils implements StorageManager {
 
         var user = this.iStorage.createOrLoad(playerUuid, playerName);
         user.setAddress(event.getAddress().getHostAddress());
-
-        if (user.isFirstJoin()){
-            this.plugin.getModuleManager().getModule(SpawnModule.class).onPlayerFirstJoin(event.getPlayer());
-        }
 
         var userEvent = new UserJoinEvent(user);
         this.plugin.getScheduler().runNextTick(wrappedTask -> userEvent.callEvent());

--- a/src/main/java/fr/maxlego08/essentials/user/ZTeleportHereRequest.java
+++ b/src/main/java/fr/maxlego08/essentials/user/ZTeleportHereRequest.java
@@ -96,6 +96,9 @@ public class ZTeleportHereRequest extends ZUtils implements TeleportRequest {
     private void teleport(TeleportationModule teleportationModule) {
         Location playerLocation = fromUser.getPlayer().getLocation();
         Location location = toUser.getPlayer().isFlying() ? playerLocation : teleportationModule.isTeleportSafety() ? toSafeLocation(playerLocation) : playerLocation;
+        if (location == null) {
+            location = playerLocation;
+        }
 
         if (teleportationModule.isTeleportToCenter()) {
             location = location.getBlock().getLocation().add(0.5, 0, 0.5);

--- a/src/main/java/fr/maxlego08/essentials/user/ZTeleportRequest.java
+++ b/src/main/java/fr/maxlego08/essentials/user/ZTeleportRequest.java
@@ -96,6 +96,9 @@ public class ZTeleportRequest extends ZUtils implements TeleportRequest {
     private void teleport(TeleportationModule teleportationModule) {
         Location playerLocation = toUser.getPlayer().getLocation();
         Location location = fromUser.getPlayer().isFlying() ? playerLocation : teleportationModule.isTeleportSafety() ? toSafeLocation(playerLocation) : playerLocation;
+        if (location == null) {
+            location = playerLocation;
+        }
 
         if (teleportationModule.isTeleportToCenter()) {
             location = location.getBlock().getLocation().add(0.5, 0, 0.5);

--- a/src/main/java/fr/maxlego08/essentials/user/ZUser.java
+++ b/src/main/java/fr/maxlego08/essentials/user/ZUser.java
@@ -395,6 +395,9 @@ public class ZUser extends ZUtils implements User {
         if (player == null) return;
 
         Location location = player.isFlying() ? toLocation : teleportationModule.isTeleportSafety() ? toSafeLocation(toLocation) : toLocation;
+        if (location == null) {
+            location = toLocation;
+        }
 
         if (teleportationModule.isTeleportToCenter()) {
             location = location.getBlock().getLocation().add(0.5, 0, 0.5);

--- a/src/main/java/fr/maxlego08/essentials/zutils/utils/FoliaJoinHelper.java
+++ b/src/main/java/fr/maxlego08/essentials/zutils/utils/FoliaJoinHelper.java
@@ -1,0 +1,62 @@
+package fr.maxlego08.essentials.zutils.utils;
+
+import fr.maxlego08.essentials.api.EssentialsPlugin;
+import fr.maxlego08.essentials.storage.ConfigStorage;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+/**
+ * Folia-safe helpers for player join flows.
+ * <p>
+ * Teleports must not run during {@link org.bukkit.event.player.PlayerJoinEvent}
+ * or {@link org.bukkit.event.player.PlayerLoginEvent}; the player is still being placed in the world.
+ */
+public final class FoliaJoinHelper {
+
+    private static final double SPAWN_TOLERANCE_SQUARED = 1.0;
+    private static final long JOIN_TELEPORT_DELAY_TICKS = 1L;
+
+    private FoliaJoinHelper() {
+    }
+
+    public static Location resolveFirstSpawnLocation() {
+        if (ConfigStorage.firstSpawnLocation != null && ConfigStorage.firstSpawnLocation.isValid()) {
+            return ConfigStorage.firstSpawnLocation.getLocation();
+        }
+        if (ConfigStorage.spawnLocation != null && ConfigStorage.spawnLocation.isValid()) {
+            return ConfigStorage.spawnLocation.getLocation();
+        }
+        return null;
+    }
+
+    public static void teleportFirstSpawnAfterJoin(EssentialsPlugin plugin, Player player) {
+        teleportAfterJoin(plugin, player, resolveFirstSpawnLocation(), true);
+    }
+
+    public static void teleportAfterJoin(EssentialsPlugin plugin, Player player, Location target) {
+        teleportAfterJoin(plugin, player, target, false);
+    }
+
+    public static void teleportAfterJoin(EssentialsPlugin plugin, Player player, Location target, boolean skipWhenAlreadyThere) {
+        if (player == null || target == null || target.getWorld() == null) {
+            return;
+        }
+
+        Location destination = target;
+        plugin.getScheduler().runAtLocationLater(player.getLocation(), () -> {
+            if (!player.isOnline()) {
+                return;
+            }
+
+            if (skipWhenAlreadyThere) {
+                Location current = player.getLocation();
+                if (current.getWorld().equals(destination.getWorld())
+                        && current.distanceSquared(destination) < SPAWN_TOLERANCE_SQUARED) {
+                    return;
+                }
+            }
+
+            plugin.getScheduler().teleportAsync(player, destination);
+        }, JOIN_TELEPORT_DELAY_TICKS);
+    }
+}

--- a/src/main/java/fr/maxlego08/essentials/zutils/utils/FoliaJoinHelper.java
+++ b/src/main/java/fr/maxlego08/essentials/zutils/utils/FoliaJoinHelper.java
@@ -15,6 +15,7 @@ public final class FoliaJoinHelper {
 
     private static final double SPAWN_TOLERANCE_SQUARED = 1.0;
     private static final long JOIN_TELEPORT_DELAY_TICKS = 1L;
+    public static final long SAFE_LOGIN_DELAY_TICKS = 5L;
 
     private FoliaJoinHelper() {
     }

--- a/src/main/java/fr/maxlego08/essentials/zutils/utils/ZUtils.java
+++ b/src/main/java/fr/maxlego08/essentials/zutils/utils/ZUtils.java
@@ -173,36 +173,56 @@ public abstract class ZUtils extends MessageUtils {
     }
 
     protected Location toSafeLocation(Location location) {
-
-        Location defaultLocation = location.clone();
-
-        if (isValid(defaultLocation)) {
-            return defaultLocation;
+        if (location == null || location.getWorld() == null) {
+            return location;
         }
 
-        location = findMeSafeLocation(defaultLocation, BlockFace.UP, 1);
-
-        return location;
-    }
-
-    protected Location findMeSafeLocation(Location location, BlockFace blockFace, int distance) {
-
-        if (distance > location.getWorld().getMaxHeight() * 2) {
-            return null;
+        Location base = location.clone();
+        if (isValid(base)) {
+            return base;
         }
 
-        Location location2 = relative(location, blockFace, distance);
-        if (isValid(location2)) {
-            return location2;
+        World world = base.getWorld();
+        int x = base.getBlockX();
+        int z = base.getBlockZ();
+        float yaw = base.getYaw();
+        float pitch = base.getPitch();
+        int startY = base.getBlockY();
+        int maxY = world.getMaxHeight() - 2;
+        int minY = world.getMinHeight() + 1;
+
+        for (int y = startY; y <= maxY; y++) {
+            Location candidate = new Location(world, x + 0.5, y, z + 0.5, yaw, pitch);
+            if (isValid(candidate)) {
+                return candidate;
+            }
         }
 
-        return findMeSafeLocation(location2, blockFace.equals(BlockFace.UP) ? BlockFace.DOWN : BlockFace.UP, distance + 1);
+        for (int y = startY - 1; y >= minY; y--) {
+            Location candidate = new Location(world, x + 0.5, y, z + 0.5, yaw, pitch);
+            if (isValid(candidate)) {
+                return candidate;
+            }
+        }
+
+        return base;
     }
 
     protected boolean isValid(Location location) {
-        if (location == null) return false;
-        if (location.getWorld() == null) return false;
-        return !location.getBlock().getType().isSolid() && !relative(location, BlockFace.UP).getBlock().getType().isSolid() && relative(location, BlockFace.DOWN).getBlock().getType().isSolid();
+        if (location == null || location.getWorld() == null) {
+            return false;
+        }
+
+        Material below = relative(location, BlockFace.DOWN).getBlock().getType();
+        Material at = location.getBlock().getType();
+        Material above = relative(location, BlockFace.UP).getBlock().getType();
+
+        return below.isSolid()
+                && below != Material.WATER && below != Material.LAVA
+                && !at.isSolid()
+                && at != Material.WATER && at != Material.LAVA
+                && !above.isSolid()
+                && above != Material.WATER && above != Material.LAVA;
     }
 
     protected Location relative(Location location, BlockFace face) {


### PR DESCRIPTION
## Summary
- Fix Folia crash on player join by deferring teleports via FoliaJoinHelper
- Rewrite SafeTeleport (toSafeLocation) with vertical scan and liquid block rejection
- Fix warp permissions: essentials.warp OR essentials.warp.<name> (lowercase)
- Fix kit and zMenu button permission checks for per-kit/per-warp access
- Delay safe-login fly activation to avoid anti-fly kicks

## Test plan
- [ ] Join server on Folia 26.x — no IllegalStateException on first spawn
- [ ] /warp with essentials.warp.<name> only (no global warp perm)
- [ ] Warp menu buttons respect per-warp permissions
- [ ] Kit menu buttons respect per-kit permissions
- [ ] Safe teleport to unsafe locations finds solid ground
- [ ] Safe-login fly does not trigger anti-cheat kicks