### PR TITLE
fix: Folia support for time/weather commands, /spawn teleport and /lightning

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/commands/commands/utils/CommandLightning.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/utils/CommandLightning.java
@@ -91,10 +91,12 @@ public final class CommandLightning extends VCommand {
     }
 
     private void strike(Location location, boolean visual) {
-        if (visual) {
-            location.getWorld().strikeLightning(location);
-        } else {
-            location.getWorld().strikeLightningEffect(location);
-        }
+        this.plugin.getScheduler().runAtLocation(location, wrappedTask -> {
+            if (visual) {
+                location.getWorld().strikeLightning(location);
+            } else {
+                location.getWorld().strikeLightningEffect(location);
+            }
+        });
     }
 }

--- a/src/main/java/fr/maxlego08/essentials/commands/commands/weather/CommandDay.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/weather/CommandDay.java
@@ -42,7 +42,7 @@ public class CommandDay extends VCommand {
         if (smooth) {
             TimeTransition.transitionWorldTime(plugin, world, dayTime);
         } else {
-            world.setFullTime(dayTime);
+            plugin.getScheduler().runNextTick(wrappedTask -> world.setFullTime(dayTime));
         }
 
         message(sender, Message.COMMAND_DAY, "%world%", world.getName());

--- a/src/main/java/fr/maxlego08/essentials/commands/commands/weather/CommandNight.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/weather/CommandNight.java
@@ -42,7 +42,7 @@ public class CommandNight extends VCommand {
         if (smooth) {
             TimeTransition.transitionWorldTime(plugin, world, nightTime);
         } else {
-            world.setFullTime(nightTime);
+            plugin.getScheduler().runNextTick(wrappedTask -> world.setFullTime(nightTime));
         }
 
         message(sender, Message.COMMAND_NIGHT, "%world%", world.getName());

--- a/src/main/java/fr/maxlego08/essentials/commands/commands/weather/CommandSun.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/weather/CommandSun.java
@@ -26,9 +26,11 @@ public class CommandSun extends VCommand {
         World world = this.argAsWorld(0, isPlayer() ? this.player.getWorld() : null);
         if (world == null) return CommandResultType.SYNTAX_ERROR;
 
-        world.setStorm(false);
-        world.setThunderDuration(0);
-        world.setThundering(false);
+        plugin.getScheduler().runNextTick(wrappedTask -> {
+            world.setStorm(false);
+            world.setThunderDuration(0);
+            world.setThundering(false);
+        });
 
         message(this.sender, Message.COMMAND_SUN, "%world%", world.getName());
 

--- a/src/main/java/fr/maxlego08/essentials/commands/commands/weather/TimeTransition.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/weather/TimeTransition.java
@@ -1,12 +1,13 @@
 package fr.maxlego08.essentials.commands.commands.weather;
 
+import com.tcoded.folialib.wrapper.task.WrappedTask;
 import fr.maxlego08.essentials.api.EssentialsPlugin;
 import org.bukkit.World;
-import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 /**
  * Utility class for smooth time transitions in worlds and for players
@@ -23,25 +24,28 @@ class TimeTransition {
         UUID worldId = world.getUID();
         TIME_CHANGING_WORLDS.add(worldId);
 
-        long startTime = world.getFullTime();
-        long diff = (targetTime - startTime + 24000) % 24000;
-
-        new BukkitRunnable() {
+        plugin.getScheduler().runTimer(new Consumer<>() {
             long progressed = 0;
+            long diff = -1;
 
             @Override
-            public void run() {
+            public void accept(WrappedTask wrappedTask) {
+                if (diff == -1) {
+                    long startTime = world.getFullTime();
+                    diff = (targetTime - startTime + 24000) % 24000;
+                }
+
                 if (progressed >= diff) {
                     world.setFullTime(targetTime);
                     TIME_CHANGING_WORLDS.remove(worldId);
-                    cancel();
+                    wrappedTask.cancel();
                     return;
                 }
 
                 world.setFullTime(world.getFullTime() + WORLD_TIME_STEP);
                 progressed += WORLD_TIME_STEP;
             }
-        }.runTaskTimer(plugin, 0L, 1L);
+        }, 1L, 1L);
     }
 
     /**

--- a/src/main/java/fr/maxlego08/essentials/user/ZUser.java
+++ b/src/main/java/fr/maxlego08/essentials/user/ZUser.java
@@ -394,18 +394,23 @@ public class ZUser extends ZUtils implements User {
         Player player = this.getPlayer();
         if (player == null) return;
 
-        Location location = player.isFlying() ? toLocation : teleportationModule.isTeleportSafety() ? toSafeLocation(toLocation) : toLocation;
+        boolean isFlying = player.isFlying();
 
-        if (teleportationModule.isTeleportToCenter()) {
-            location = location.getBlock().getLocation().add(0.5, 0, 0.5);
-            location.setYaw(toLocation.getYaw());
-            location.setPitch(toLocation.getPitch());
-        }
+        this.plugin.getScheduler().runAtLocation(toLocation, wrappedTask -> {
 
-        this.teleportNow(location);
-        if (message != null) {
-            message(this, message, args);
-        }
+            Location location = isFlying ? toLocation : teleportationModule.isTeleportSafety() ? toSafeLocation(toLocation) : toLocation;
+
+            if (teleportationModule.isTeleportToCenter()) {
+                location = location.getBlock().getLocation().add(0.5, 0, 0.5);
+                location.setYaw(toLocation.getYaw());
+                location.setPitch(toLocation.getPitch());
+            }
+
+            this.teleportNow(location);
+            if (message != null) {
+                message(this, message, args);
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
On Folia some commands fail with the syntax error message because the real exception is managed by `safelyPerformCommand`

the real cause is thread check violations

`/day` `/night` `/sun` world time and weather must be changed on the global region thread also `TimeTransition` used a `BukkitRunnable` butt its not supported on Folia

`/spawn` after a cross world tp `toSafeLocation` reads destination blocks from the bad region thread

`/lightning` entity spawned from the senders thread

fixed by going through the folialib scheduler w `runNextTick` `runTimer` & `runAtLocation`

tested on Folia 26.1.2 rn but should be good on any