### PR TITLE
Check teleport permission before teleporting in /tpworld

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/commands/commands/teleport/CommandTeleportWorld.java
+++ b/src/main/java/fr/maxlego08/essentials/commands/commands/teleport/CommandTeleportWorld.java
@@ -30,17 +30,15 @@ public class CommandTeleportWorld extends VCommand {
 
         if (player == null || world == null) return CommandResultType.SYNTAX_ERROR;
 
+        if (player != this.player && !hasPermission(sender, Permission.ESSENTIALS_TP_WORLD_OTHER)) {
+            return CommandResultType.NO_PERMISSION;
+        }
+
         player.teleportAsync(world.getSpawnLocation());
 
         if (player == this.player) {
-
             message(sender, Message.COMMAND_WORLD_TELEPORT_SELF, "%world%", world.getName());
         } else {
-
-            if (!hasPermission(sender, Permission.ESSENTIALS_TP_WORLD_OTHER)) {
-                return CommandResultType.NO_PERMISSION;
-            }
-
             message(player, Message.COMMAND_WORLD_TELEPORT_SELF, "%world%", world.getName());
             message(sender, Message.COMMAND_WORLD_TELEPORT_OTHER, "%world%", world.getName(), player);
         }


### PR DESCRIPTION
The `/tpworld <world> [player]` command teleports the target player before checking the `essentials.tp.world.other` permission.

This means a player with only `essentials.tp.world` (but not `.other`) can still teleport other players to any world — they just get a `NO_PERMISSION` message after the teleport has already happened.

Steps to reproduce:
1. Give a player `essentials.tp.world` but NOT `essentials.tp.world.other`
2. Run `/tpworld world_nether OtherPlayer`
3. OtherPlayer is teleported to the nether, sender sees "no permission"

Fix: move the permission check above the `teleportAsync` call, so unauthorized senders are rejected before the teleport is triggered.
