### PR TITLE
Fix infinite recursion in ZStorageManager.getType()

### DIFF
--- a/src/main/java/fr/maxlego08/essentials/storage/ZStorageManager.java
+++ b/src/main/java/fr/maxlego08/essentials/storage/ZStorageManager.java
@@ -27,12 +27,13 @@ public class ZStorageManager extends ZUtils implements StorageManager {
 
     private final IStorage iStorage;
     private final EssentialsPlugin plugin;
+    private final StorageType storageType;
 
     public ZStorageManager(EssentialsPlugin plugin) {
         this.plugin = plugin;
-        StorageType storageType = plugin.getConfiguration().getStorageType();
-        this.iStorage = switch (storageType) {
-            case HIKARICP, SQLITE, MYSQL, MARIADB -> new SqlStorage(plugin, storageType);
+        this.storageType = plugin.getConfiguration().getStorageType();
+        this.iStorage = switch (this.storageType) {
+            case HIKARICP, SQLITE, MYSQL, MARIADB -> new SqlStorage(plugin, this.storageType);
             default -> new JsonStorage(plugin);
         };
     }
@@ -56,7 +57,7 @@ public class ZStorageManager extends ZUtils implements StorageManager {
 
     @Override
     public StorageType getType() {
-        return this.plugin.getStorageManager().getType();
+        return this.storageType;
     }
 
     @EventHandler(priority = EventPriority.HIGHEST)


### PR DESCRIPTION
The `getType()` method in `ZStorageManager` calls `this.plugin.getStorageManager().getType()`, which returns the same `ZStorageManager` instance and calls itself recursively with no base case. Any invocation causes a `StackOverflowError`.

Fix: store the `StorageType` in a field during construction (it's already resolved locally in the constructor) and return it directly in `getType()`.
